### PR TITLE
fixed signout issue

### DIFF
--- a/src/app/(auth)/sign-in/sign-in-form.tsx
+++ b/src/app/(auth)/sign-in/sign-in-form.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { GitHubIcon } from "@/components/icons/GitHubIcon";
-import { GoogleIcon } from "@/components/icons/GoogleIcon";
 import { LoadingButton } from "@/components/loading-button";
 import { PasswordInput } from "@/components/password-input";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -47,7 +44,6 @@ export function SignInForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get("redirect");
-  console.log("🚀 ~ sign-in-form.tsx:50 ~ SignInForm ~ redirect:", redirect);
 
   const form = useForm<SignInValues>({
     resolver: zodResolver(signInSchema),
@@ -77,21 +73,21 @@ export function SignInForm() {
     }
   }
 
-  async function handleSocialSignIn(provider: "google" | "github") {
-    // TODO: Handle social sign in
-    setError(null);
-    setLoading(true);
+  // async function handleSocialSignIn(provider: "google" | "github") {
+  //   // TODO: Handle social sign in
+  //   setError(null);
+  //   setLoading(true);
 
-    const { error } = await authClient.signIn.social({
-      provider,
-      callbackURL: redirect ?? "/dashboard",
-    });
-    setLoading(false);
+  //   const { error } = await authClient.signIn.social({
+  //     provider,
+  //     callbackURL: `${process.env.NEXT_PUBLIC_AUTH_URL}/auth/callback`,
+  //   });
+  //   setLoading(false);
 
-    if (error) {
-      setError(error.message ?? "Something went wrong!");
-    }
-  }
+  //   if (error) {
+  //     setError(error.message ?? "Something went wrong!");
+  //   }
+  // }
 
   return (
     <Card className="w-full max-w-md">
@@ -174,7 +170,7 @@ export function SignInForm() {
               Login
             </LoadingButton>
 
-            <div className="flex w-full flex-col items-center justify-between gap-2">
+            {/* <div className="flex w-full flex-col items-center justify-between gap-2">
               <Button
                 type="button"
                 variant="outline"
@@ -196,7 +192,7 @@ export function SignInForm() {
                 <GitHubIcon />
                 Sign in with Github
               </Button>
-            </div>
+            </div> */}
           </form>
         </Form>
       </CardContent>

--- a/src/app/api/sign-out/route.ts
+++ b/src/app/api/sign-out/route.ts
@@ -1,18 +1,27 @@
 import { NextResponse } from "next/server";
-import { toast } from "sonner";
 import { authClient } from "../../../lib/auth-client";
 
-export async function POST() {
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const redirectUrl = searchParams.get("redirect") || "/";
+  const decodedRedirectUrl = decodeURIComponent(redirectUrl);
   try {
+    // const cookieStore = await cookies();
     await authClient.signOut();
-    toast.success("Signed out successfully");
-    return NextResponse.json({ success: true });
+    const res = NextResponse.redirect(decodedRedirectUrl);
+
+    res.cookies.delete("better-auth.session_token");
+
+    return res;
   } catch (error) {
     console.error("Sign out error:", error);
-    toast.error("Something went wrong");
+
     return NextResponse.json(
-      { success: false, error: error instanceof Error ? error.message : String(error) },
-      { status: 500 }
+      {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sign out now uses a GET endpoint with support for a redirect query (?redirect=...), defaulting to the home page.
  - Immediate redirect after signing out for a smoother flow.

- Bug Fixes
  - Session cookie is explicitly cleared on sign out to prevent lingering sessions.

- Chores
  - Removed Google and GitHub social sign-in options from the sign-in form.
  - Simplified sign-out feedback by removing in-app toasts in favor of redirect-based confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->